### PR TITLE
Fix Swift errors assignment

### DIFF
--- a/Sources/XCLogParser/activityparser/ActivityParser.swift
+++ b/Sources/XCLogParser/activityparser/ActivityParser.swift
@@ -373,8 +373,8 @@ public class ActivityParser {
         guard let classRefToken = iterator.next() else {
             throw XCLogParserError.parseError("Unexpected EOF parsing ClassRef")
         }
-        //The first time there is a classRef of an specific Type,
-        //There is a className before that defines the Type
+        // The first time there is a classRef of an specific Type,
+        // There is a className before that defines the Type
         if case Token.className = classRefToken {
             guard let classRefToken = iterator.next() else {
                 throw XCLogParserError.parseError("Unexpected EOF parsing ClassRef")

--- a/Sources/XCLogParser/commands/Version.swift
+++ b/Sources/XCLogParser/commands/Version.swift
@@ -21,6 +21,6 @@ import Foundation
 
 public struct Version {
 
-    public static let current = "0.2.27"
+    public static let current = "0.2.28"
 
 }

--- a/Sources/XCLogParser/lexer/Lexer.swift
+++ b/Sources/XCLogParser/lexer/Lexer.swift
@@ -121,15 +121,15 @@ public final class Lexer {
         if scanner.scanCharacters(from: typeDelimiters, into: &delimiters), let delimiters = delimiters {
             let delimiters = String(delimiters)
             if delimiters.count > 1 {
-                //if we found a string, we discard other type delimiters because there are part of the string
+                // if we found a string, we discard other type delimiters because there are part of the string
                 let tokenString = TokenType.string
                 if let char = delimiters.first, tokenString.rawValue == String(char) {
                     scanner.scanLocation -= delimiters.count - 1
                     return [tokenString]
                 }
             }
-            //sometimes we found one or more nil list (-) next to the type delimiter
-            //in that case we'll return the delimiter and one or more `Token.null`
+            // sometimes we found one or more nil list (-) next to the type delimiter
+            // in that case we'll return the delimiter and one or more `Token.null`
             return delimiters.compactMap { character -> TokenType? in
                 TokenType(rawValue: String(character))
             }

--- a/Sources/XCLogParser/parser/BuildStep+Builder.swift
+++ b/Sources/XCLogParser/parser/BuildStep+Builder.swift
@@ -124,6 +124,40 @@ extension BuildStep {
                          swiftTypeCheckTimes: swiftTypeCheckTimes)
     }
 
+    func with(errors newErrors: [Notice]?, notes newNotes: [Notice]?, warnings newWarnings: [Notice]?) -> BuildStep {
+        return BuildStep(type: type,
+                         machineName: machineName,
+                         buildIdentifier: buildIdentifier,
+                         identifier: identifier,
+                         parentIdentifier: parentIdentifier,
+                         domain: domain,
+                         title: title,
+                         signature: signature,
+                         startDate: startDate,
+                         endDate: endDate,
+                         startTimestamp: startTimestamp,
+                         endTimestamp: endTimestamp,
+                         duration: duration,
+                         detailStepType: detailStepType,
+                         buildStatus: buildStatus,
+                         schema: schema,
+                         subSteps: subSteps,
+                         warningCount: newWarnings?.count ?? 0,
+                         errorCount: newErrors?.count ?? 0,
+                         architecture: architecture,
+                         documentURL: documentURL,
+                         warnings: newWarnings,
+                         errors: newErrors,
+                         notes: newNotes,
+                         swiftFunctionTimes: swiftFunctionTimes,
+                         fetchedFromCache: fetchedFromCache,
+                         compilationEndTimestamp: compilationEndTimestamp,
+                         compilationDuration: compilationDuration,
+                         clangTimeTraceFile: clangTimeTraceFile,
+                         linkerStatistics: linkerStatistics,
+                         swiftTypeCheckTimes: swiftTypeCheckTimes)
+    }
+
     func withFilteredNotices() -> BuildStep {
         let filteredNotes = filterNotices(notes)
         let filteredWarnings = filterNotices(warnings)
@@ -302,6 +336,6 @@ extension BuildStep {
         guard let notices = notices else {
             return nil
         }
-        return notices.filter { $0.documentURL.isEmpty || $0.documentURL == documentURL }
+        return self.documentURL.isEmpty ? [] : notices
     }
 }

--- a/Sources/XCLogParser/parser/BuildStep.swift
+++ b/Sources/XCLogParser/parser/BuildStep.swift
@@ -78,7 +78,6 @@ public enum DetailStepType: String, Encodable {
 
     /// Precompile Bridging header
     case precompileBridgingHeader
-    //case PrecompileSwiftBridgingHeader
 
     /// Non categorized step
     case other

--- a/Sources/XCLogParser/parser/Notice.swift
+++ b/Sources/XCLogParser/parser/Notice.swift
@@ -163,3 +163,32 @@ public class Notice: Codable {
         return number
     }
 }
+
+extension Notice: Hashable {
+    public static func == (lhs: Notice, rhs: Notice) -> Bool {
+        return
+            lhs.characterRangeEnd == rhs.characterRangeEnd &&
+            lhs.characterRangeStart == rhs.characterRangeStart &&
+            lhs.detail == rhs.detail &&
+            lhs.documentURL == rhs.documentURL &&
+            lhs.endingColumnNumber == rhs.endingColumnNumber &&
+            lhs.endingLineNumber == rhs.endingLineNumber &&
+            lhs.startingColumnNumber == rhs.startingColumnNumber &&
+            lhs.startingLineNumber == rhs.startingLineNumber &&
+            lhs.title == rhs.title &&
+            lhs.type == rhs.type
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(characterRangeEnd)
+        hasher.combine(characterRangeStart)
+        hasher.combine(detail)
+        hasher.combine(documentURL)
+        hasher.combine(endingColumnNumber)
+        hasher.combine(endingLineNumber)
+        hasher.combine(startingColumnNumber)
+        hasher.combine(startingLineNumber)
+        hasher.combine(title)
+        hasher.combine(type)
+    }
+}

--- a/Sources/XCLogParser/parser/ParserBuildSteps.swift
+++ b/Sources/XCLogParser/parser/ParserBuildSteps.swift
@@ -222,8 +222,8 @@ public final class ParserBuildSteps {
 
     private func getDuration(startTimeInterval: Double, endTimeInterval: Double) -> Double {
         var duration = endTimeInterval - startTimeInterval
-        //If the endtime is almost the same as the endtime, we got a constant
-        //in the tokens and a date in the future (year 4001). Here we normalize it to 0.0 secs
+        // If the endtime is almost the same as the endtime, we got a constant
+        // in the tokens and a date in the future (year 4001). Here we normalize it to 0.0 secs
         if endTimeInterval >= 63113904000.0 {
             duration = 0.0
         }

--- a/Tests/XCLogParserTests/LogFinderTests.swift
+++ b/Tests/XCLogParserTests/LogFinderTests.swift
@@ -67,7 +67,7 @@ class LogFinderTests: XCTestCase {
         }
     }
 
-    //Swift is crashing in Linux when trying to create a temp directory with a modificationDate
+    // Swift is crashing in Linux when trying to create a temp directory with a modificationDate
     #if !os(Linux)
     func testGetLatestLogForProjectFolder() throws {
         guard let derivedDataDir = derivedDataDir else {


### PR DESCRIPTION
When we breakdown the Swift files in a Swift module, we weren't assigning correctly an error or warning to its source file causing to some errors not being shown in the Reports.
For instance, when the actual file that failed was not reported by the Swift Compiler. We couldn't attribute the error to one of the files in the Build Log. With this fix we are assigning to a file in the same Swift Module, so the error is correctly reported.

SwiftLint was reporting new issues, I also fixed them in this PR