### PR TITLE
Create CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @xclogparser-committers @polac24 @ecamacho @aleksandergrzyb @CognitiveDisson


### PR DESCRIPTION
Fixes #154 

Unfortunately I can't add all members to the `xclogparser-committers` team because they are not part of the org, so we need to add them singularly and hopefully that works. cc: @keith 