### PR TITLE
Add validation error support

### DIFF
--- a/Sources/XCLogParser/activityparser/ActivityParser.swift
+++ b/Sources/XCLogParser/activityparser/ActivityParser.swift
@@ -524,7 +524,7 @@ public class ActivityParser {
         }
         switch token {
         case .string(let string):
-            return string
+            return string.trimmingCharacters(in: .whitespacesAndNewlines)
         case .null:
             return ""
         default:

--- a/Sources/XCLogParser/extensions/ArrayExtension.swift
+++ b/Sources/XCLogParser/extensions/ArrayExtension.swift
@@ -50,7 +50,8 @@ extension Array where Element: Notice {
             $0.type == .clangError ||
             $0.type == .linkerError ||
             $0.type == .packageLoadingError ||
-            $0.type == .scriptPhaseError
+            $0.type == .scriptPhaseError ||
+            $0.type == .failedCommandError
         }
     }
 

--- a/Sources/XCLogParser/parser/BuildStep.swift
+++ b/Sources/XCLogParser/parser/BuildStep.swift
@@ -85,6 +85,12 @@ public enum DetailStepType: String, Encodable {
     /// For steps that are not a detail step
     case none
 
+    /// Validate watch, extensions binaries
+    case validateEmbeddedBinary
+
+    /// Validate app
+    case validate
+
     // swiftlint:disable:next cyclomatic_complexity
     public static func getDetailType(signature: String) -> DetailStepType {
         switch signature {
@@ -118,6 +124,10 @@ public enum DetailStepType: String, Encodable {
             return .swiftAggregatedCompilation
         case Prefix("PrecompileSwiftBridgingHeader "):
             return .precompileBridgingHeader
+        case Prefix("ValidateEmbeddedBinary "):
+            return .validateEmbeddedBinary
+        case Prefix("Validate "):
+            return .validate
         default:
             return .other
         }

--- a/Sources/XCLogParser/parser/NoticeType.swift
+++ b/Sources/XCLogParser/parser/NoticeType.swift
@@ -62,6 +62,9 @@ public enum NoticeType: String, Codable {
     /// Error running a Build Phase's script
     case scriptPhaseError
 
+    /// Failed command error (e.g. ValidateEmbeddedBinary, CodeSign)
+    case failedCommandError
+
     // swiftlint:disable:next cyclomatic_complexity
     public static func fromTitle(_ title: String) -> NoticeType? {
         switch title {
@@ -89,6 +92,8 @@ public enum NoticeType: String, Codable {
             return .scriptPhaseError
         case Prefix("error: Swiftc"):
             return .swiftError
+        case Suffix("failed with a nonzero exit code"):
+            return .failedCommandError
         default:
             return .note
         }

--- a/Tests/XCLogParserTests/ActivityParserTests.swift
+++ b/Tests/XCLogParserTests/ActivityParserTests.swift
@@ -339,4 +339,13 @@ class ActivityParserTests: XCTestCase {
         XCTAssertEqual("file:///project/Project.xcodeproj", documentLocation.documentURLString)
         XCTAssertEqual(2.2, documentLocation.timestamp)
     }
+
+    func testTrimmingWhiteCharsInStrings() throws {
+        var locationTokens = textDocumentLocationTokens
+        locationTokens[0] = Token.string(" file:///project/EntityComponentView.m\n")
+        var iterator = locationTokens.makeIterator()
+        let documentLocation = try parser.parseDVTTextDocumentLocation(iterator: &iterator)
+
+        XCTAssertEqual("file:///project/EntityComponentView.m", documentLocation.documentURLString)
+    }
 }


### PR DESCRIPTION
Support errors coming from external commands triggered by Xcode. That includes `codesign`, `validate`, `dsymutil` etc.

Here is an example error message of a failed binary validation:
```
Command ValidateEmbeddedBinary failed with a nonzero exit code
```

Example  binary validation command:
```
ValidateEmbeddedBinary /absolute/path/xxx.app (in target 'xxx' from project 'xxx')
```