### PR TITLE
Bump XCLogParser version

### DIFF
--- a/Sources/XCLogParser/commands/Version.swift
+++ b/Sources/XCLogParser/commands/Version.swift
@@ -21,6 +21,6 @@ import Foundation
 
 public struct Version {
 
-    public static let current = "0.2.32"
+    public static let current = "0.2.33"
 
 }


### PR DESCRIPTION
Bumping is required for a release.