### PR TITLE
Log Types

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/krzyzanowskim/CryptoSwift.git",
         "state": {
           "branch": null,
-          "revision": "e2bc81be54d71d566a52ca17c3983d141c30aa70",
-          "version": "1.3.3"
+          "revision": "4b0565384d3c4c588af09e660535b2c7c9bf5b39",
+          "version": "1.4.2"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {
           "branch": null,
-          "revision": "92646c0cdbaca076c8d3d0207891785b3379cbff",
-          "version": "0.3.1"
+          "revision": "e394bf350e38cb100b6bc4172834770ede1b7232",
+          "version": "1.0.3"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -12,9 +12,9 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/1024jp/GzipSwift", from: "5.1.0"),
-        .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", .exact("1.3.3")),
+        .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", from: "1.3.3"),
         .package(url: "https://github.com/kylef/PathKit.git", from: "1.0.1"),
-        .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "0.3.0")),
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
     ],
     targets: [
         .target(

--- a/Sources/XCLogParser/commands/CommandHandler.swift
+++ b/Sources/XCLogParser/commands/CommandHandler.swift
@@ -21,10 +21,16 @@ import Foundation
 
 public struct CommandHandler {
 
-    let logFinder = LogFinder()
-    let activityLogParser = ActivityParser()
+    let logFinder: LogFinder
+    let activityLogParser: ActivityParser
 
-    public init() { }
+    public init(
+        logFinder: LogFinder = .init(),
+        activityLogParser: ActivityParser = .init()
+    ) {
+        self.logFinder = logFinder
+        self.activityLogParser = activityLogParser
+    }
 
     public func handle(command: Command) throws {
         switch command.action {

--- a/Sources/XCLogParser/loglocation/LogFinder.swift
+++ b/Sources/XCLogParser/loglocation/LogFinder.swift
@@ -32,7 +32,7 @@ public struct LogFinder {
 
     let logManifestFile = "LogStoreManifest.plist"
 
-    let emmptyDirResponseMessage = """
+    let emptyDirResponseMessage = """
     Error. Couldn't find the derived data directory.
     Please use the --filePath option to specify the path to the xcactivitylog file you want to parse.
     """
@@ -199,7 +199,7 @@ public struct LogFinder {
         if let result = try executeXcodeBuild(args: arguments) {
             return try parseXcodeBuildDir(result)
         }
-        throw LogError.xcodeBuildError(emmptyDirResponseMessage)
+        throw LogError.xcodeBuildError(emptyDirResponseMessage)
     }
 
     /// Gets the latest xcactivitylog file path for the given projectFolder
@@ -248,7 +248,7 @@ public struct LogFinder {
         if let result = try executeXcodeBuild(args: arguments) {
             return try parseXcodeBuildDir(result)
         }
-        throw LogError.xcodeBuildError(emmptyDirResponseMessage)
+        throw LogError.xcodeBuildError(emptyDirResponseMessage)
     }
 
     /// Returns the latest xcactivitylog file path in the given directory
@@ -317,6 +317,6 @@ public struct LogFinder {
                 .replacingOccurrences(of: buildDirSettingsPrefix, with: "")
                 .replacingOccurrences(of: "Build/Products", with: logsDir)
         }
-        throw LogError.xcodeBuildError(emmptyDirResponseMessage)
+        throw LogError.xcodeBuildError(emptyDirResponseMessage)
     }
 }

--- a/Sources/XCLogParser/loglocation/LogFinder.swift
+++ b/Sources/XCLogParser/loglocation/LogFinder.swift
@@ -24,13 +24,13 @@ import XcodeHasher
 /// Helper methods to locate Xcode's Log directory and its content
 public struct LogFinder {
 
-    let buildDirSettingsPrefix = "BUILD_DIR = "
+    let buildDirSettingsPrefix: String
 
-    let xcodebuildPath = "/usr/bin/xcodebuild"
+    let xcodebuildPath: String
 
-    let logsDir = "/Logs/Build/"
+    let logsDir: String
 
-    let logManifestFile = "LogStoreManifest.plist"
+    let logManifestFile: String
 
     let emptyDirResponseMessage = """
     Error. Couldn't find the derived data directory.
@@ -44,7 +44,17 @@ public struct LogFinder {
         return homeDirURL.appendingPathComponent("Library/Developer/Xcode/DerivedData", isDirectory: true)
     }
 
-    public init() {}
+    public init(
+        buildDirSettingsPrefix: String = "BUILD_DIR = ",
+        xcodebuildPath: String = "/usr/bin/xcodebuild",
+        logsDir: String  = "/Logs/Build/",
+        logManifestFile: String = "LogStoreManifest.plist"
+    ) {
+        self.buildDirSettingsPrefix = buildDirSettingsPrefix
+        self.xcodebuildPath = xcodebuildPath
+        self.logsDir = logsDir
+        self.logManifestFile = logManifestFile
+    }
 
     public func findLatestLogWithLogOptions(_ logOptions: LogOptions) throws -> URL {
         guard logOptions.xcactivitylogPath.isEmpty else {

--- a/Sources/XCLogParser/loglocation/LogFinder.swift
+++ b/Sources/XCLogParser/loglocation/LogFinder.swift
@@ -28,7 +28,7 @@ public struct LogFinder {
 
     let xcodebuildPath: String
 
-    let logsDir: String
+    let logType: LogType
 
     let logManifestFile: String
 
@@ -47,12 +47,12 @@ public struct LogFinder {
     public init(
         buildDirSettingsPrefix: String = "BUILD_DIR = ",
         xcodebuildPath: String = "/usr/bin/xcodebuild",
-        logsDir: String  = "/Logs/Build/",
+        logType: LogType  = .build,
         logManifestFile: String = "LogStoreManifest.plist"
     ) {
         self.buildDirSettingsPrefix = buildDirSettingsPrefix
         self.xcodebuildPath = xcodebuildPath
-        self.logsDir = logsDir
+        self.logType = logType
         self.logManifestFile = logManifestFile
     }
 
@@ -121,8 +121,8 @@ public struct LogFinder {
         // when xcodebuild is run with -derivedDataPath the logs are at the root level
         if logOptions.derivedDataPath.isEmpty == false {
             if FileManager.default.fileExists(atPath:
-                derivedData.appendingPathComponent(logsDir).path) {
-                return derivedData.appendingPathComponent(logsDir)
+                                                derivedData.appendingPathComponent(logType.path).path) {
+                return derivedData.appendingPathComponent(logType.path)
             }
         }
         if logOptions.projectLocation.isEmpty == false {
@@ -195,7 +195,7 @@ public struct LogFinder {
                 with --file or the right DerivedData folder with --derived_data
                 """)
         }
-        return match.appendingPathComponent(logsDir)
+        return match.appendingPathComponent(logType.path)
     }
 
     /// Gets the full path of the Build/Logs directory for the given project
@@ -294,7 +294,7 @@ public struct LogFinder {
             .replacingOccurrences(of: ".xcworkspace", with: "")
             .replacingOccurrences(of: ".xcodeproj", with: "")
         let hash = try XcodeHasher.hashString(for: path.string)
-        return "\(projectName)-\(hash)".appending(logsDir)
+        return "\(projectName)-\(hash)".appending(logType.path)
     }
 
     private func executeXcodeBuild(args: [String]) throws -> String? {
@@ -325,7 +325,7 @@ public struct LogFinder {
         if let settings = buildDirSettings.first {
             return settings.trimmingCharacters(in: .whitespacesAndNewlines)
                 .replacingOccurrences(of: buildDirSettingsPrefix, with: "")
-                .replacingOccurrences(of: "Build/Products", with: logsDir)
+                .replacingOccurrences(of: "Build/Products", with: logType.path)
         }
         throw LogError.xcodeBuildError(emptyDirResponseMessage)
     }

--- a/Sources/XCLogParser/loglocation/LogType.swift
+++ b/Sources/XCLogParser/loglocation/LogType.swift
@@ -1,0 +1,27 @@
+//
+//  LogType.swift
+//  
+//
+//  Created by Danny Gilbert on 2/2/22.
+//
+
+import Foundation
+
+public enum LogType: String {
+    case build = "Build"
+    case indexBuild = "Index Build"
+    case install = "Install"
+    case issues = "Issues"
+    case package = "Package"
+    case run = "Run"
+    case test = "Test"
+    case updateSigning = "Update Signing"
+}
+
+// MARK: - Log Location
+public extension LogType {
+
+    var path: String {
+        "/Logs/\(self)/"
+    }
+}

--- a/Sources/XCLogParserApp/commands/ParseCommand.swift
+++ b/Sources/XCLogParserApp/commands/ParseCommand.swift
@@ -26,6 +26,9 @@ struct ParseCommand: ParsableCommand {
         commandName: "parse",
         abstract: "Parses the content of an xcactivitylog file"
     )
+    
+    @Option(name: .long, help: "Type of .xactivitylog file to look for.")
+    var logs: LogType = .build
 
     @Option(name: .long, help: "The path to a .xcactivitylog file.")
     var file: String?
@@ -157,7 +160,9 @@ struct ParseCommand: ParsableCommand {
         guard let xclReporter = Reporter(rawValue: reporter) else {
             return
         }
-        let commandHandler = CommandHandler()
+        let commandHandler = CommandHandler(
+            logFinder: .init(logType: logs)
+        )
         let logOptions = LogOptions(projectName: project ?? "",
                                     xcworkspacePath: workspace ?? "",
                                     xcodeprojPath: xcodeproj ?? "",

--- a/Sources/XCLogParserApp/extensions/LogType+.swift
+++ b/Sources/XCLogParserApp/extensions/LogType+.swift
@@ -1,0 +1,11 @@
+//
+//  LogType+.swift
+//  
+//
+//  Created by Danny Gilbert on 2/2/22.
+//
+
+import XCLogParser
+import ArgumentParser
+
+extension LogType: ExpressibleByArgument { }


### PR DESCRIPTION
# Details
Opens up the parsing feature to more [LogTypes](https://github.com/spydercapriani/XCLogParser/blob/b3237738cd3550962ecfdf9fbb0fa2a5f5b85958/Sources/XCLogParser/loglocation/LogType.swift).

Idea behind this approach is to make it easier to parse things like Package logs so as to potentially allow metric collection around dependencies. For example, Package + Build Logs can provide a deeper picture of what developement cycle looks like since package resolution happen before builds take place but aren't necessarily being accounted for.

