### PR TITLE
Xcode 14: add parsing for DVTMemberDocumentLocation

### DIFF
--- a/Sources/XCLogParser/activityparser/ActivityParser.swift
+++ b/Sources/XCLogParser/activityparser/ActivityParser.swift
@@ -310,6 +310,8 @@ public class ActivityParser {
             return try parseDVTDocumentLocation(iterator: &iterator)
         } else if className == String(describing: IBDocumentMemberLocation.self) {
             return try parseIBDocumentMemberLocation(iterator: &iterator)
+        } else if className == String(describing: DVTMemberDocumentLocation.self) {
+            return try parseDVTMemberDocumentLocation(iterator: &iterator)
         }
         throw XCLogParserError.parseError("Unexpected className found parsing DocumentLocation \(className)")
     }
@@ -490,6 +492,12 @@ public class ActivityParser {
                                             memberIdentifier: try parseIBMemberID(iterator: &iterator),
                                             attributeSearchLocation:
                                                 try parseIBAttributeSearchLocation(iterator: &iterator))
+    }
+    
+    private func parseDVTMemberDocumentLocation(iterator: inout IndexingIterator<[Token]>) throws -> DVTMemberDocumentLocation {
+        return DVTMemberDocumentLocation(documentURLString: try parseAsString(token: iterator.next()),
+                                         timestamp: try parseAsDouble(token: iterator.next()),
+                                         some: try parseAsString(token: iterator.next()))
     }
 
     private func parseIBMemberID(iterator: inout IndexingIterator<[Token]>)

--- a/Sources/XCLogParser/activityparser/IDEActivityModel.swift
+++ b/Sources/XCLogParser/activityparser/IDEActivityModel.swift
@@ -333,6 +333,17 @@ public class DVTDocumentLocation: Encodable {
 
 }
 
+public class DVTMemberDocumentLocation: DVTDocumentLocation {
+    public let some: String // Sample: irs-zY-n9e
+    
+    public init(documentURLString: String, timestamp: Double, some: String) {
+        self.some = some
+        
+        super.init(documentURLString: documentURLString,
+                   timestamp: timestamp)
+    }
+}
+
 public class DVTTextDocumentLocation: DVTDocumentLocation {
     public let startingLineNumber: UInt64
     public let startingColumnNumber: UInt64


### PR DESCRIPTION
DVTMemberDocumentLocation is introduced in Xcode 14.

- [x] Fix parsing by adding DVTMemberDocumentLocation
- [ ] Give proper name to the new property

Related to [issue #169](https://github.com/MobileNativeFoundation/XCLogParser/issues/169)