### PR TITLE
Support Xcode 14 logs

### DIFF
--- a/Sources/XCLogParser/activityparser/ActivityParser.swift
+++ b/Sources/XCLogParser/activityparser/ActivityParser.swift
@@ -310,6 +310,8 @@ public class ActivityParser {
             return try parseDVTDocumentLocation(iterator: &iterator)
         } else if className == String(describing: IBDocumentMemberLocation.self) {
             return try parseIBDocumentMemberLocation(iterator: &iterator)
+        } else if className == String(describing: DVTMemberDocumentLocation.self) {
+            return try parseDVTMemberDocumentLocation(iterator: &iterator)
         }
         throw XCLogParserError.parseError("Unexpected className found parsing DocumentLocation \(className)")
     }
@@ -563,6 +565,13 @@ public class ActivityParser {
             return value == 1
         }
         throw XCLogParserError.parseError("Unexpected token parsing Bool: \(token)")
+    }
+
+    private func parseDVTMemberDocumentLocation(iterator: inout IndexingIterator<[Token]>)
+    throws -> DVTMemberDocumentLocation {
+        return DVTMemberDocumentLocation(documentURLString: try parseAsString(token: iterator.next()),
+                                         timestamp: try parseAsDouble(token: iterator.next()),
+                                         member: try parseAsString(token: iterator.next()))
     }
 
 }

--- a/Sources/XCLogParser/activityparser/IDEActivityModel.swift
+++ b/Sources/XCLogParser/activityparser/IDEActivityModel.swift
@@ -568,3 +568,25 @@ public class IBDocumentMemberLocation: DVTDocumentLocation {
         try container.encode(attributeSearchLocation, forKey: .attributeSearchLocation)
     }
 }
+
+// MARK: Added in Xcode 14
+
+////  From DVTFoundation.framework
+public class DVTMemberDocumentLocation: DVTDocumentLocation, Equatable {
+
+    public let member: String
+
+    public init(documentURLString: String, timestamp: Double, member: String) {
+        self.member = member
+        super.init(documentURLString: documentURLString, timestamp: timestamp)
+    }
+
+    // MARK: Equatable method
+
+    public static func == (lhs: DVTMemberDocumentLocation, rhs: DVTMemberDocumentLocation) -> Bool {
+        return lhs.documentURLString == rhs.documentURLString &&
+        lhs.timestamp == rhs.timestamp &&
+        lhs.member == rhs.member
+    }
+
+}

--- a/Sources/XCLogParser/commands/Version.swift
+++ b/Sources/XCLogParser/commands/Version.swift
@@ -21,6 +21,6 @@ import Foundation
 
 public struct Version {
 
-    public static let current = "0.2.33"
+    public static let current = "0.2.34"
 
 }

--- a/Tests/XCLogParserTests/ActivityParserTests.swift
+++ b/Tests/XCLogParserTests/ActivityParserTests.swift
@@ -348,4 +348,31 @@ class ActivityParserTests: XCTestCase {
 
         XCTAssertEqual("file:///project/EntityComponentView.m", documentLocation.documentURLString)
     }
+
+    let expectedDVTMemberDocumentLocation: DVTMemberDocumentLocation = DVTMemberDocumentLocation(
+        documentURLString: "file:///project/EntityComponentView.m",
+        timestamp: 2.2,
+        member: "abcdef")
+
+    let memberDocumentLocationTokens: [Token] = {
+        return [
+            Token.className("DVTMemberDocumentLocation"),
+            Token.classNameRef("DVTMemberDocumentLocation"),
+            Token.string("file:///project/EntityComponentView.m"),
+            Token.double(2.2),
+            Token.string("abcdef")]
+    }()
+
+    func testParseDVTMemberDocumentLocation() throws {
+        var iterator = memberDocumentLocationTokens.makeIterator()
+        let documentLocation = try parser.parseDocumentLocation(iterator: &iterator)
+        XCTAssert(documentLocation is DVTMemberDocumentLocation,
+                  "Document location should be a DVTMemberDocumentLocation")
+
+        guard let documentMemberLocation = documentLocation as? DVTMemberDocumentLocation else {
+            return
+        }
+        XCTAssertEqual(expectedDVTMemberDocumentLocation, documentMemberLocation)
+    }
+
 }


### PR DESCRIPTION
Fixes https://github.com/MobileNativeFoundation/XCLogParser/issues/169 to parse Xcode 14 logs.


Found the missing property name from https://github.com/MobileNativeFoundation/XCLogParser/pull/170 by class dumping Xcode 14's DVTFoundation.framework 


