### PR TITLE
Bump Xcode to 14.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,9 @@ jobs:
           args: --strict
 
   macOS:
-    runs-on: macOS-latest
+    runs-on: macos-12
     env:
-      XCODE_VERSION: ${{ '12.5' }}
+      XCODE_VERSION: ${{ '14.1' }}
     steps:
       - name: Select Xcode
         run: "sudo xcode-select -s /Applications/Xcode_$XCODE_VERSION.app"
@@ -29,7 +29,7 @@ jobs:
   linux:
     runs-on: ubuntu-latest
     container:
-      image: swift:5.2
+      image: swift:5.7.1
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,9 +6,9 @@ on:
 jobs:
   macOS:
     name: Add macOS binaries to release
-    runs-on: macOS-latest
+    runs-on: macos-12
     env:
-      XCODE_VERSION: ${{ '12.5' }}
+      XCODE_VERSION: ${{ '14.1' }}
     steps:
       - name: Select Xcode
         run: "sudo xcode-select -s /Applications/Xcode_$XCODE_VERSION.app"
@@ -45,7 +45,7 @@ jobs:
     name: Add Linux binaries to release
     runs-on: ubuntu-latest
     container:
-      image: swift:5.2
+      image: swift:5.7.1
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM swift:5.1
+FROM swift:5.5
 RUN apt-get update && apt-get install -y zlib1g-dev ruby
 CMD cd xclogparser && swift build

--- a/Package.swift
+++ b/Package.swift
@@ -23,9 +23,13 @@ let package = Package(
         ),
         .target(
             name: "XCLogParser",
-            dependencies: ["Gzip", "XcodeHasher", "PathKit"]
+            dependencies: [
+                .product(name: "Gzip", package: "GzipSwift"),
+                "XcodeHasher",
+                "PathKit"
+            ]
         ),
-        .target(
+        .executableTarget(
             name: "XCLogParserApp",
             dependencies: [
                 "XCLogParser",

--- a/Package@swift-5.0.swift
+++ b/Package@swift-5.0.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/README.md
+++ b/README.md
@@ -513,8 +513,8 @@ xclogparser parse --file path/to/log.xcactivitylog --reporter html --output buil
 
 | Environment | Version     |
 | ----------- |-------------|
-| 🛠 Xcode    | 11.0        |
-| 🐦 Language | Swift 5.0   |
+| 🛠 Xcode    | 13.0        |
+| 🐦 Language | Swift 5.5   |
 
 ## Status
 

--- a/Sources/XCLogParser/commands/Version.swift
+++ b/Sources/XCLogParser/commands/Version.swift
@@ -21,6 +21,6 @@ import Foundation
 
 public struct Version {
 
-    public static let current = "0.2.34"
+    public static let current = "0.2.35"
 
 }


### PR DESCRIPTION
Bumping to the latest Xcode 14.1 and Swift 5.5

### Notes
1. A bump is a prerequisite for swift-argument-parser upgrade in #177 that require SPM 5.5
1. Switching to macos-12 because the current macos-latest (now macos-11 doesn't include it: [link](https://github.com/actions/runner-images/tree/bb5b6307df028c9272c797b1a1de231ae0d6af5e#available-images))