### PR TITLE
DeprecatedWarnings: Check for type note

### DIFF
--- a/Sources/XCLogParser/parser/Notice+Parser.swift
+++ b/Sources/XCLogParser/parser/Notice+Parser.swift
@@ -187,7 +187,8 @@ extension Notice {
             return true
         }
         // Support for Swift and ObjC code marked as deprecated
-        if type == .swiftError || type == .swiftWarning || type == .projectWarning || type == .clangWarning {
+        if type == .swiftError || type == .swiftWarning || type == .projectWarning || type == .clangWarning
+            || type == .note {
             return text.contains(" deprecated:")
                 || text.contains("was deprecated in")
                 || text.contains("has been deprecated")


### PR DESCRIPTION
With Xcode 14 - it seems that swift deprecation warnings have the type `note`.

Example 
```
{
                  "characterRangeStart" : 0,
                  "startingColumnNumber" : 34,
                  "endingColumnNumber" : 34,
                  "characterRangeEnd" : 18446744073709551615,
                  "detail" : "\/Sources\/SourceDir\/PermissionHandler.swift:24:34: warning: 'authorizationS
tatus()' was deprecated in iOS 14.0\r        switch CLLocationManager.authorizationStatus() {\r                                 ^",
                  "title" : "'authorizationStatus()' was deprecated in iOS 14.0",
                  "endingLineNumber" : 24,
                  "type" : "note",
                  "documentURL" : "file:\/\/\/\/Sources\/SourceDir\/PermissionHandler.swift",
                  "startingLineNumber" : 24,
                  "severity" : 1
                }
```

Should fix https://github.com/MobileNativeFoundation/XCLogParser/issues/171