### PR TITLE
Remove occurrences of single quotes in filenames

### DIFF
--- a/Resources/js/app.js
+++ b/Resources/js/app.js
@@ -545,10 +545,10 @@ function showWarnings(target) {
 
 function itemSelected(target, selectedItem) {
     if (selectedItem.type === 'target') {
-        const fileName = selectedItem.identifier.replaceAll(' ', '_');
+        const fileName = selectedItem.identifier.replaceAll(' ', '_').replaceAll('\\\'', '_');
         window.location.href = window.location.href.replace('index.html', fileName + '.html');
     } else if (selectedItem.type === 'detail') {
-        const targetId = selectedItem.parentIdentifier.replaceAll(' ', '_');
+        const targetId = selectedItem.parentIdentifier.replaceAll(' ', '_').replaceAll('\\\'', '_');
         if (target === 'main') {
             const stepUrl = window.location.href.replace(encodeURI('{{file_name}}'), targetId + '.html');
             window.location.href = stepUrl + "?step=" + selectedItem.identifier;

--- a/Sources/XCLogParser/generated/HtmlReporterResources.swift
+++ b/Sources/XCLogParser/generated/HtmlReporterResources.swift
@@ -637,10 +637,10 @@ function showWarnings(target) {
 
 function itemSelected(target, selectedItem) {
     if (selectedItem.type === 'target') {
-        const fileName = selectedItem.identifier.replaceAll(' ', '_');
+        const fileName = selectedItem.identifier.replaceAll(' ', '_').replaceAll('\\\'', '_');
         window.location.href = window.location.href.replace('index.html', fileName + '.html');
     } else if (selectedItem.type === 'detail') {
-        const targetId = selectedItem.parentIdentifier.replaceAll(' ', '_');
+        const targetId = selectedItem.parentIdentifier.replaceAll(' ', '_').replaceAll('\\\'', '_');
         if (target === 'main') {
             const stepUrl = window.location.href.replace(encodeURI('{{file_name}}'), targetId + '.html');
             window.location.href = stepUrl + "?step=" + selectedItem.identifier;
@@ -1046,7 +1046,7 @@ public static let indexHTML =
   <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.23.0/moment-with-locales.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/apexcharts"></script>
   <script src="https://cdn.datatables.net/1.10.20/js/jquery.dataTables.min.js"></script>
-    <script type="text/javascript" src="js/{{app_file}}"></script>
+  <script type="text/javascript" src="js/{{app_file}}"></script>
 </body>
 </html>
 
@@ -1302,7 +1302,7 @@ public static let stepHTML =
   <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
   <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.1.2/handlebars.min.js"></script>
-      <script type="text/javascript" src="js/{{data_file}}"></script>
+  <script type="text/javascript" src="js/{{data_file}}"></script>
   <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.23.0/moment-with-locales.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/apexcharts"></script>
   <script type="text/javascript" src="js/step.js"></script>

--- a/Sources/XCLogParser/reporter/HtmlReporter.swift
+++ b/Sources/XCLogParser/reporter/HtmlReporter.swift
@@ -125,6 +125,7 @@ public struct HtmlReporter: LogReporter {
             stepsWithErrors.append(contentsOf: getStepsWithErrors(target: target))
             stepsWithWarnings.append(contentsOf: getStepsWithWarnings(target: target))
             let targetName = target.identifier.replacingOccurrences(of: " ", with: "_")
+                .replacingOccurrences(of: "'", with: "_")
             let name = "\(targetName).js"
             let json = try encoder.encode(target.flatten())
             guard let jsonString = String(data: json, encoding: .utf8) else {


### PR DESCRIPTION
This PR introduces a replacement of `'` in .html filenames into `_`.

Fixes https://github.com/MobileNativeFoundation/XCLogParser/issues/142

Can be tested by adding a custom machine name with single quote e.g. `--machine_name "Patrik's macbook"`