### PR TITLE
Add `SwiftCompile ` as detailType

### DIFF
--- a/Sources/XCLogParser/parser/BuildStep.swift
+++ b/Sources/XCLogParser/parser/BuildStep.swift
@@ -96,7 +96,7 @@ public enum DetailStepType: String, Encodable {
         switch signature {
         case Prefix("CompileC "):
             return .cCompilation
-        case Prefix("CompileSwift "):
+        case Prefix("CompileSwift "), Prefix("SwiftCompile "):
             return .swiftCompilation
         case Prefix("Ld "):
             return .linker


### PR DESCRIPTION
It seems that in Xcode 14 the signature prefix for swiftCompilation is now `SwiftCompile ...`. I added it in the parsing logic to keep supporting the old Xcode versions as well

Test this by parsing a project with Swift files and look for the presence of Swift files in the HTML format output
<img width="263" alt="Screenshot 2022-11-29 at 13 22 00" src="https://user-images.githubusercontent.com/1339530/204528002-81f698da-d5d3-46d7-b99d-15017fe1d3a6.png">
