### PR TITLE
Fix deprecation notice detection

### DIFF
--- a/Sources/XCLogParser/parser/Notice+Parser.swift
+++ b/Sources/XCLogParser/parser/Notice+Parser.swift
@@ -192,6 +192,7 @@ extension Notice {
             return text.contains(" deprecated:")
                 || text.contains("was deprecated in")
                 || text.contains("has been deprecated")
+                || text.contains("is deprecated")
         }
         return false
     }


### PR DESCRIPTION
### Detail
Some deprecation messages were not included in the final report. In cases where the message was in the `/Users/lenar/Desktop/DeprecateTest/DeprecateTest/ViewController.swift:15:9 'testDeprecate()' is deprecated`
 format. I've added handling for such a message and now all deprecation messages should be captured.

Should fix https://github.com/MobileNativeFoundation/XCLogParser/issues/183 