### PR TITLE
Change CryptoSwift not to require the exact version

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/krzyzanowskim/CryptoSwift.git",
         "state": {
           "branch": null,
-          "revision": "e2bc81be54d71d566a52ca17c3983d141c30aa70",
-          "version": "1.3.3"
+          "revision": "eee9ad754926c40a0f7e73f152357d37b119b7fa",
+          "version": "1.7.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/1024jp/GzipSwift", from: "5.1.0"),
-        .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", .exact("1.3.3")),
+        .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", from: "1.3.3"),
         .package(url: "https://github.com/kylef/PathKit.git", from: "1.0.1"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.0"),
     ],


### PR DESCRIPTION
Requiring only 1.3.3 is very restrictive if the package is used together with other packages needing CryptoSwift because they almost always use a different version.