### PR TITLE
Revert "Add `SwiftCompile ` as detailType"

### DIFF
--- a/Sources/XCLogParser/parser/BuildStep.swift
+++ b/Sources/XCLogParser/parser/BuildStep.swift
@@ -96,7 +96,7 @@ public enum DetailStepType: String, Encodable {
         switch signature {
         case Prefix("CompileC "):
             return .cCompilation
-        case Prefix("CompileSwift "), Prefix("SwiftCompile "):
+        case Prefix("CompileSwift "):
             return .swiftCompilation
         case Prefix("Ld "):
             return .linker


### PR DESCRIPTION
Reverts MobileNativeFoundation/XCLogParser#182 due to https://github.com/MobileNativeFoundation/XCLogParser/issues/196