### PR TITLE
Bump version to 0.2.38

### DIFF
--- a/Sources/XCLogParser/commands/Version.swift
+++ b/Sources/XCLogParser/commands/Version.swift
@@ -21,6 +21,6 @@ import Foundation
 
 public struct Version {
 
-    public static let current = "0.2.37"
+    public static let current = "0.2.38"
 
 }


### PR DESCRIPTION
A new version (`0.2.38`) was released to address https://github.com/MobileNativeFoundation/XCLogParser/issues/196 however the new version still reports itself as `0.2.37` 

```
% brew info xclogparser
==> xclogparser: stable 0.2.38 (bottled)
Tool to parse the SLF serialization format used by Xcode
https://github.com/MobileNativeFoundation/XCLogParser
/opt/homebrew/Cellar/xclogparser/0.2.38 (6 files, 3.4MB) *
  Poured from bottle using the formulae.brew.sh API on 2024-01-11 at 21:02:46
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/x/xclogparser.rb
License: Apache-2.0
==> Requirements
Required: Xcode >= 13.0 (on macOS) ✔
==> Analytics
install: 386 (30 days), 1,023 (90 days), 2,674 (365 days)
install-on-request: 386 (30 days), 1,023 (90 days), 2,674 (365 days)
build-error: 0 (30 days)
% xclogparser version  
XCLogParser 0.2.37
```

Probably a second bump will be necessary to make everything in sync again. 