### PR TITLE
Add build statistics to Log Manifest Entry, exact build duration

### DIFF
--- a/Sources/XCLogParser/logmanifest/LogManifest.swift
+++ b/Sources/XCLogParser/logmanifest/LogManifest.swift
@@ -46,16 +46,28 @@ public struct LogManifest {
                 let timeStartedRecording = entry.value["timeStartedRecording"] as? Double,
                 let timeStoppedRecording = entry.value["timeStoppedRecording"] as? Double,
                 let className = entry.value["className"] as? String,
-                let type = LogManifestEntryType.buildFromClassName(className)
+                let type = LogManifestEntryType.buildFromClassName(className),
+                let primaryObservable = entry.value["primaryObservable"] as? [String: Any],
+                let totalNumberOfAnalyzerIssues = primaryObservable["totalNumberOfAnalyzerIssues"] as? Int,
+                let totalNumberOfErrors = primaryObservable["totalNumberOfErrors"] as? Int,
+                let totalNumberOfWarnings = primaryObservable["totalNumberOfWarnings"] as? Int,
+                let totalNumberOfTestFailures = primaryObservable["totalNumberOfTestFailures"] as? Int,
+                let highLevelStatus = primaryObservable["highLevelStatus"] as? String
                 else {
                     throw LogError.invalidLogManifest("The file at \(path) is not a valid " +
                         "LogManifest file.")
             }
             let startDate = Date(timeIntervalSinceReferenceDate: timeStartedRecording)
             let endDate = Date(timeIntervalSinceReferenceDate: timeStoppedRecording)
-            let timestampStart = Int(startDate.timeIntervalSince1970.rounded())
-            let timestampEnd = Int(endDate.timeIntervalSince1970.rounded())
-
+            let timestampStart = startDate.timeIntervalSince1970
+            let timestampEnd = endDate.timeIntervalSince1970
+            let statistics = LogManifestEntryStatistics(
+                totalNumberOfErrors: totalNumberOfErrors,
+                totalNumberOfAnalyzerIssues: totalNumberOfAnalyzerIssues,
+                highLevelStatus: highLevelStatus,
+                totalNumberOfTestFailures: totalNumberOfTestFailures,
+                totalNumberOfWarnings: totalNumberOfWarnings
+            )
             return LogManifestEntry(uniqueIdentifier: uniqueIdentifier,
                                     title: title,
                                     scheme: scheme,
@@ -63,7 +75,9 @@ public struct LogManifest {
                                     timestampStart: timestampStart,
                                     timestampEnd: timestampEnd,
                                     duration: timestampEnd - timestampStart,
-                                    type: type)
+                                    type: type,
+                                    statistics: statistics
+            )
             }.sorted(by: { lhs, rhs -> Bool in
                 return lhs.timestampStart > rhs.timestampStart
             })

--- a/Sources/XCLogParser/logmanifest/LogManifestModel.swift
+++ b/Sources/XCLogParser/logmanifest/LogManifestModel.swift
@@ -42,13 +42,14 @@ public struct LogManifestEntry: Encodable {
     public let title: String
     public let scheme: String
     public let fileName: String
-    public let timestampStart: Int
-    public let timestampEnd: Int
-    public let duration: Int
+    public let timestampStart: TimeInterval
+    public let timestampEnd: TimeInterval
+    public let duration: Double
     public let type: LogManifestEntryType
-
+    public let statistics: LogManifestEntryStatistics
+    
     public init(uniqueIdentifier: String, title: String, scheme: String, fileName: String,
-                timestampStart: Int, timestampEnd: Int, duration: Int, type: LogManifestEntryType) {
+                timestampStart: TimeInterval, timestampEnd: TimeInterval, duration: Double, type: LogManifestEntryType, statistics: LogManifestEntryStatistics) {
         self.uniqueIdentifier = uniqueIdentifier
         self.title = title
         self.scheme = scheme
@@ -57,6 +58,23 @@ public struct LogManifestEntry: Encodable {
         self.timestampEnd = timestampEnd
         self.duration = duration
         self.type = type
+        self.statistics = statistics
     }
 
+}
+
+public struct LogManifestEntryStatistics: Encodable {
+    public let totalNumberOfErrors: Int
+    public let totalNumberOfAnalyzerIssues: Int
+    public let highLevelStatus: String
+    public let totalNumberOfTestFailures: Int
+    public let totalNumberOfWarnings: Int
+    
+    public init(totalNumberOfErrors: Int, totalNumberOfAnalyzerIssues: Int, highLevelStatus: String, totalNumberOfTestFailures: Int, totalNumberOfWarnings: Int) {
+        self.totalNumberOfErrors = totalNumberOfErrors
+        self.totalNumberOfAnalyzerIssues = totalNumberOfAnalyzerIssues
+        self.highLevelStatus = highLevelStatus
+        self.totalNumberOfTestFailures = totalNumberOfTestFailures
+        self.totalNumberOfWarnings = totalNumberOfWarnings
+    }
 }

--- a/Tests/XCLogParserTests/LogManifestTests.swift
+++ b/Tests/XCLogParserTests/LogManifestTests.swift
@@ -45,6 +45,14 @@ class LogManifestTests: XCTestCase {
 <dict>
 <key>highLevelStatus</key>
 <string>W</string>
+<key>totalNumberOfAnalyzerIssues</key>
+<integer>0</integer>
+<key>totalNumberOfErrors</key>
+<integer>0</integer>
+<key>totalNumberOfTestFailures</key>
+<integer>0</integer>
+<key>totalNumberOfWarnings</key>
+<integer>2</integer>
 </dict>
 <key>schemeIdentifier-containerName</key>
 <string>MyApp</string>
@@ -95,7 +103,13 @@ class LogManifestTests: XCTestCase {
              "documentTypeString": "&lt;nil&gt;",
              "domainType": "Xcode.IDEActivityLogDomainType.BuildLog",
              "fileName": "599BC5A8-5E6A-4C16-A71E-A8D6301BAC07.xcactivitylog",
-             "highLevelStatus": "E",
+             "primaryObservable": [
+                 "highLevelStatus": "E",
+                 "totalNumberOfErrors": 1,
+                 "totalNumberOfAnalyzerIssues": 0,
+                 "totalNumberOfTestFailures": 0,
+                 "totalNumberOfWarnings": 2
+             ],
              "schemeIdentifier-containerName": "MyApp project",
              "schemeIdentifier-schemeName": "MyApp",
              "schemeIdentifier-sharedScheme": 1,
@@ -109,7 +123,13 @@ class LogManifestTests: XCTestCase {
                  "documentTypeString": "&lt;nil&gt;",
                  "domainType": "Xcode.IDEActivityLogDomainType.BuildLog",
                  "fileName": "D1FEAFFA-2E88-4221-9CD2-AB607529381D.xcactivitylog",
-                 "highLevelStatus": "E",
+                 "primaryObservable": [
+                     "highLevelStatus": "E",
+                     "totalNumberOfErrors": 1,
+                     "totalNumberOfAnalyzerIssues": 0,
+                     "totalNumberOfTestFailures": 0,
+                     "totalNumberOfWarnings": 2
+                 ],
                  "schemeIdentifier-containerName": "MyApp project",
                  "schemeIdentifier-schemeName": "MyApp",
                  "schemeIdentifier-sharedScheme": 1,
@@ -128,13 +148,10 @@ class LogManifestTests: XCTestCase {
             return
         }
 
+        
         let startDate = Date(timeIntervalSinceReferenceDate: firstStartedRecording)
         let endDate = Date(timeIntervalSinceReferenceDate: firstStoppedRecording)
-        let calendar = Calendar.current
-        guard let expectedDuration = calendar.dateComponents([.second], from: startDate, to: endDate).second else {
-            XCTFail("Error creating an expected duration field")
-            return
-        }
+        let expectedDuration = endDate.timeIntervalSince1970 - startDate.timeIntervalSince1970
         XCTAssertEqual(expectedDuration, latestLog.duration)
     }
 


### PR DESCRIPTION
I've updated `LogManifestEntry` for Xcode's latest format, adding statistics like number of warnings and errors. This allows to filter out failed builds without loading `.xcactivitylog`.

I've also changed the build duration from an `Int` into a `Double` and removed the rounding, so build durations are more precise. I believe it's up to the users of the framework to decide to round the build duration instead of us showing wrong build durations from the start. 