### PR TITLE
Encode log data to ascii string using c string pointer

### DIFF
--- a/Sources/XCLogParser/loglocation/LogLoader.swift
+++ b/Sources/XCLogParser/loglocation/LogLoader.swift
@@ -26,7 +26,17 @@ public struct LogLoader {
         do {
             let data = try Data(contentsOf: url)
             let unzipped = try data.gunzipped()
-            guard let contents =  String(data: unzipped, encoding: .ascii) else {
+            let string: String? = unzipped.withUnsafeBytes { pointer in
+                guard let charPointer = pointer
+                    .assumingMemoryBound(to: CChar.self)
+                    .baseAddress 
+                else {
+                    return nil
+                }
+
+                return String(cString: charPointer, encoding: .ascii)
+            }
+            guard let contents = string else {
                 throw LogError.readingFile(url.path)
             }
             return contents

--- a/Sources/XCLogParser/loglocation/LogLoader.swift
+++ b/Sources/XCLogParser/loglocation/LogLoader.swift
@@ -29,7 +29,7 @@ public struct LogLoader {
             let string: String? = unzipped.withUnsafeBytes { pointer in
                 guard let charPointer = pointer
                     .assumingMemoryBound(to: CChar.self)
-                    .baseAddress 
+                    .baseAddress
                 else {
                     return nil
                 }


### PR DESCRIPTION
Swift 6 String's `init?(data: Data, encoding: String.Encoding)` fails validation during encoding `utf8` data to `ascii` and returns `nil`.

As proposed solution we inspect memory buffer bound to `UInt8/CChar` bytes, assuming they are null-terminted which allows us to produce a new string by simply copying them and interpreting as `ascii`.
