### PR TITLE
fix: bump version to match with the 0.2.41 release

### DIFF
--- a/Sources/XCLogParser/commands/Version.swift
+++ b/Sources/XCLogParser/commands/Version.swift
@@ -21,6 +21,6 @@ import Foundation
 
 public struct Version {
 
-    public static let current = "0.2.39"
+    public static let current = "0.2.41"
 
 }


### PR DESCRIPTION
seeing the version mismatch with the new release in https://github.com/Homebrew/homebrew-core/pull/201480