### PR TITLE
Fix flat structure detection by checking against all the `subSections`

### DIFF
--- a/Sources/XCLogParser/parser/IDEActivityLogSection+Parsing.swift
+++ b/Sources/XCLogParser/parser/IDEActivityLogSection+Parsing.swift
@@ -42,8 +42,7 @@ extension IDEActivityLogSection {
     func groupedByTarget() -> IDEActivityLogSection {
         // The only way to know if the structure is flatten is to check the first elements
         // for the `(in target 'ABC' from project Project)` string
-        let firstElements = subSections.prefix(15) // we only analyze up to the first 15 subsections
-        let isFlatten = firstElements.contains { $0.getTargetFromCommand() != nil }
+        let isFlatten = subSections.contains { $0.getTargetFromCommand() != nil }
         if isFlatten {
             let mainTarget = "$MainTarget"
             let targetsDictionary = subSections.reduce(


### PR DESCRIPTION
I noticed the report I was getting did not group the targets of the activity log. The check against the first 15 elements that's hardcoded in the project turns out to be too limiting. After I removed it, the grouping worked as expected.

What's the reason why the limit of 15 was added?
