### PR TITLE
Fix parsing failing due to new TaskBacktrace activity log attachment

### DIFF
--- a/Sources/XCLogParser/activityparser/ActivityParser.swift
+++ b/Sources/XCLogParser/activityparser/ActivityParser.swift
@@ -380,12 +380,27 @@ public class ActivityParser {
             }
 
             if className == "IDEFoundation.\(String(describing: IDEActivityLogSectionAttachment.self))" {
-                let jsonType = IDEActivityLogSectionAttachment.BuildOperationTaskMetrics.self
-                return try IDEActivityLogSectionAttachment(identifier: try parseAsString(token: iterator.next()),
-                                                           majorVersion: try parseAsInt(token: iterator.next()),
-                                                           minorVersion: try parseAsInt(token: iterator.next()),
-                                                           metrics: try parseAsJson(token: iterator.next(),
-                                                                                    type: jsonType))
+                let identifier = try parseAsString(token: iterator.next())
+                switch identifier.components(separatedBy: "ActivityLogSectionAttachment.").last {
+                case .some("TaskMetrics"):
+                    let jsonType = IDEActivityLogSectionAttachment.BuildOperationTaskMetrics.self
+                    return try IDEActivityLogSectionAttachment(identifier: identifier,
+                                                               majorVersion: try parseAsInt(token: iterator.next()),
+                                                               minorVersion: try parseAsInt(token: iterator.next()),
+                                                               metrics: try parseAsJson(token: iterator.next(),
+                                                                                         type: jsonType),
+                                                                backtraces: [])
+                case .some("TaskBacktrace"):
+                    let jsonType = [IDEActivityLogSectionAttachment.BuildOperationTaskBacktrace].self
+                    return try IDEActivityLogSectionAttachment(identifier: identifier,
+                                                               majorVersion: try parseAsInt(token: iterator.next()),
+                                                               minorVersion: try parseAsInt(token: iterator.next()),
+                                                               metrics: nil,
+                                                               backtraces: try parseAsJson(token: iterator.next(),
+                                                                                         type: jsonType) ?? [])
+                default:
+                    throw XCLogParserError.parseError("Unexpected attachment identifier \(identifier)")
+                }
             }
             throw XCLogParserError.parseError("Unexpected className found parsing IDEConsoleItem \(className)")
     }

--- a/Sources/XCLogParser/activityparser/ActivityParser.swift
+++ b/Sources/XCLogParser/activityparser/ActivityParser.swift
@@ -389,15 +389,15 @@ public class ActivityParser {
                                                                minorVersion: try parseAsInt(token: iterator.next()),
                                                                metrics: try parseAsJson(token: iterator.next(),
                                                                                          type: jsonType),
-                                                                backtraces: [])
+                                                                backtrace: nil)
                 case .some("TaskBacktrace"):
-                    let jsonType = [IDEActivityLogSectionAttachment.BuildOperationTaskBacktrace].self
+                    let jsonType = IDEActivityLogSectionAttachment.BuildOperationTaskBacktrace.self
                     return try IDEActivityLogSectionAttachment(identifier: identifier,
                                                                majorVersion: try parseAsInt(token: iterator.next()),
                                                                minorVersion: try parseAsInt(token: iterator.next()),
                                                                metrics: nil,
-                                                               backtraces: try parseAsJson(token: iterator.next(),
-                                                                                         type: jsonType) ?? [])
+                                                               backtrace: try parseAsJson(token: iterator.next(),
+                                                                                         type: jsonType))
                 default:
                     throw XCLogParserError.parseError("Unexpected attachment identifier \(identifier)")
                 }

--- a/Sources/XCLogParser/logmanifest/LogManifest.swift
+++ b/Sources/XCLogParser/logmanifest/LogManifest.swift
@@ -25,7 +25,7 @@ public struct LogManifest {
 
     public init() {}
 
-    public func getWithLogOptions(_ logOptions: LogOptions) throws  -> [LogManifestEntry] {
+    public func getWithLogOptions(_ logOptions: LogOptions) throws -> [LogManifestEntry] {
         let logFinder = LogFinder()
         let logManifestURL = try logFinder.findLogManifestWithLogOptions(logOptions)
         let logManifestDictionary = try getDictionaryFromURL(logManifestURL)

--- a/Tests/XCLogParserTests/ActivityParserTests.swift
+++ b/Tests/XCLogParserTests/ActivityParserTests.swift
@@ -346,7 +346,7 @@ class ActivityParserTests: XCTestCase {
         XCTAssertEqual("localizedResultString", logSection.localizedResultString)
         XCTAssertEqual("xcbuildSignature", logSection.xcbuildSignature)
         XCTAssertEqual(2, logSection.attachments.count)
-        XCTAssertEqual(logSection.attachments[0].backtraces[0].category, .ruleNeverBuilt)
+        XCTAssertEqual(logSection.attachments[0].backtrace?.frames.first?.category, .ruleNeverBuilt)
         XCTAssertEqual(logSection.attachments[1].metrics?.wcDuration, 1)
         XCTAssertEqual(0, logSection.unknown)
     }

--- a/Tests/XCLogParserTests/ActivityParserTests.swift
+++ b/Tests/XCLogParserTests/ActivityParserTests.swift
@@ -97,7 +97,13 @@ class ActivityParserTests: XCTestCase {
                          Token.string("501796C4-6BE4-4F80-9F9D-3269617ECC17"),
                          Token.string("localizedResultString"),
                          Token.string("xcbuildSignature"),
-                         Token.list(1),
+                         Token.list(2),
+                         Token.classNameRef("IDEFoundation.IDEActivityLogSectionAttachment"),
+                         Token.string("com.apple.dt.ActivityLogSectionAttachment.TaskBacktrace"),
+                         Token.int(1),
+                         Token.int(0),
+                         // swiftlint:disable:next line_length
+                         Token.json(#"[{"description":"'Planning Swift module ConcurrencyExtras (arm64)' had never run","category":{"ruleNeverBuilt":{}},"identifier":{"storage":{"task":{"_0":[0,80,50,58,116,97,114,103,101,116,45,67,111,110,99,117,114,114,101,110,99,121,69,120,116,114,97,115,45,101,102,52,50,51,48,52,53,57,52,98,102,56,53,50,102,52,51,56,101,102,55,99,51,97,49,51,54,98,50,99,57,48,100,102,56,55,49,56,97,102,50,98,57,100,51,97,97,99,48,100,48,100,99,97,50,50,98,52,99,50,57,99,50,45,58,66,101,116,97,32,68,101,98,117,103,58,51,99,57,97,99,57,53,50,98,52,99,56,49,100,57,99,99,49,55,100,49,97,102,52,55,49,97,48,52,53,101,56]}}},"frameKind":{"genericTask":{}}}]"#),
                          Token.classNameRef("IDEFoundation.IDEActivityLogSectionAttachment"),
                          Token.string("com.apple.dt.ActivityLogSectionAttachment.TaskMetrics"),
                          Token.int(1),
@@ -339,7 +345,9 @@ class ActivityParserTests: XCTestCase {
         XCTAssertEqual("501796C4-6BE4-4F80-9F9D-3269617ECC17", logSection.uniqueIdentifier)
         XCTAssertEqual("localizedResultString", logSection.localizedResultString)
         XCTAssertEqual("xcbuildSignature", logSection.xcbuildSignature)
-        XCTAssertEqual(1, logSection.attachments.count)
+        XCTAssertEqual(2, logSection.attachments.count)
+        XCTAssertEqual(logSection.attachments[0].backtraces[0].category, .ruleNeverBuilt)
+        XCTAssertEqual(logSection.attachments[1].metrics?.wcDuration, 1)
         XCTAssertEqual(0, logSection.unknown)
     }
 


### PR DESCRIPTION
I'm not sure when `TaskBacktrace` was introduced but it seems to be a new of the section attachment. Example value from after tokenization:
```
[type: list, count: 2]
[type: classNameRef, className: "IDEFoundation.IDEActivityLogSectionAttachment"]
[type: string, value: "com.apple.dt.ActivityLogSectionAttachment.TaskBacktrace"]
[type: int, value: 1]
[type: int, value: 0]
[type: json, value: [{"description":"'Planning Swift module ConcurrencyExtras (arm64)' had never run","category":{"ruleNeverBuilt":{}},"identifier":{"storage":{"task":{"_0":[0,80,50,58,116,97,114,103,101,116,45,67,111,110,99,117,114,114,101,110,99,121,69,120,116,114,97,115,45,101,102,52,50,51,48,52,53,57,52,98,102,56,53,50,102,52,51,56,101,102,55,99,51,97,49,51,54,98,50,99,57,48,100,102,56,55,49,56,97,102,50,98,57,100,51,97,97,99,48,100,48,100,99,97,50,50,98,52,99,50,57,99,50,45,58,66,101,116,97,32,68,101,98,117,103,58,51,99,57,97,99,57,53,50,98,52,99,56,49,100,57,99,99,49,55,100,49,97,102,52,55,49,97,48,52,53,101,56]}}},"frameKind":{"genericTask":{}}}]]
[type: classNameRef, className: "IDEFoundation.IDEActivityLogSectionAttachment"]
[type: string, value: "com.apple.dt.ActivityLogSectionAttachment.TaskMetrics"]
[type: int, value: 1]
[type: int, value: 0]
[type: json, value: {"utime":15551,"stime":15551,"maxRSS":0,"wcStartTime":771519075106417,"wcDuration":15551}]
```

The second attachment is the one we currently parse, support for which was introduced in https://github.com/MobileNativeFoundation/XCLogParser/pull/204.

The first attachment is new – and currently `XCLogParser` fails when parsing it because it expects all attachments to be a task metric.

This PR adds support for parsing it. The JSON value is quite odd – I decided to parse just the `category` and `description`, discarding the `identifier` and `frameKind`. If you feel strongly, I can try adding support for those as well, but I'm not sure how they would be useful.